### PR TITLE
Add SSR templates and static handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ __pycache__/
 *.sqlite3
 .env
 .venv/
-/static/
+staticfiles/
 /media/
 .DS_Store
 .idea/

--- a/README.md
+++ b/README.md
@@ -48,3 +48,18 @@ curl -X POST http://localhost:8000/api/marketplace/proposals/ \
   -H 'Content-Type: application/json' \
   -d '{"project":1,"cover_letter":"Готов сделать","bid_amount":500,"eta_days":10}'
 ```
+
+## SSR Pages & Static
+
+HTML templates live in `templates/` and static assets in `static/`.
+
+Collect static files for production:
+
+```bash
+python manage.py collectstatic --noinput
+```
+
+To add a new server-rendered page:
+
+1. Create a template inside `templates/pages/`.
+2. Add a corresponding class-based view and URL pattern.

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,0 +1,10 @@
+from typing import Dict
+
+def project_meta(request) -> Dict[str, object]:
+    return {
+        "PROJECT_NAME": "Uzinex Freelance",
+        "NAV_LINKS": [
+            {"name": "Home", "url": "home"},
+            {"name": "Projects", "url": "projects_list"},
+        ],
+    }

--- a/core/settings.py
+++ b/core/settings.py
@@ -43,15 +43,16 @@ ROOT_URLCONF = 'core.urls'
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "core.context_processors.project_meta",
             ],
         },
     },
@@ -60,18 +61,24 @@ TEMPLATES = [
 WSGI_APPLICATION = 'core.wsgi.application'
 
 DATABASES = {
-    'default': dj_database_url.config(default=os.environ.get('DATABASE_URL'))
+    "default": dj_database_url.config(
+        default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}"
+    )
 }
 
 AUTH_PASSWORD_VALIDATORS = []
 
 LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Tashkent'
 USE_I18N = True
 USE_TZ = True
 
-STATIC_URL = 'static/'
-STATIC_ROOT = BASE_DIR / 'static'
+STATIC_URL = "static/"
+STATICFILES_DIRS = [BASE_DIR / "static"]
+STATIC_ROOT = BASE_DIR / "staticfiles"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+LOGIN_URL = "/auth/login/"
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 

--- a/core/tests_ssr.py
+++ b/core/tests_ssr.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class SSRTests(TestCase):
+    def setUp(self):
+        self.client_user = User.objects.create_user(
+            username="client", password="pass", role="client"
+        )
+
+    def test_basic_pages(self):
+        for name in ["home", "login", "register", "projects_list"]:
+            resp = self.client.get(reverse(name))
+            self.assertEqual(resp.status_code, 200)
+
+    def test_login_post(self):
+        resp = self.client.post(
+            reverse("login"), {"username": "client", "password": "pass"}, follow=True
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Logged in successfully")
+
+    def test_project_create_requires_login(self):
+        resp = self.client.get(reverse("project_create"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn(reverse("login"), resp.url)

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,13 +1,40 @@
 from django.contrib import admin
 from django.urls import path, include
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from core.views import HomeView
+from users.views import LoginView, RegisterView, MeView, ProfileEditView, logout_view
+from marketplace.views_ssr import (
+    ProjectsListView,
+    ProjectDetailView,
+    ProjectCreateView,
+)
+from messaging.views_ssr import ThreadListView, ThreadDetailView
+
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
-    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema')),
-    path('api/auth/', include('users.urls')),
-    path('api/marketplace/', include('marketplace.urls')),
-    path('api/messaging/', include('messaging.urls')),
-    path('api/payments/', include('payments.urls')),
+    path("admin/", admin.site.urls),
+
+    # SSR pages
+    path("", HomeView.as_view(), name="home"),
+    path("auth/login/", LoginView.as_view(), name="login"),
+    path("auth/register/", RegisterView.as_view(), name="register"),
+    path("auth/logout/", logout_view, name="logout"),
+
+    path("me/", MeView.as_view(), name="me"),
+    path("me/edit/", ProfileEditView.as_view(), name="profile_edit"),
+
+    path("projects/", ProjectsListView.as_view(), name="projects_list"),
+    path("projects/new/", ProjectCreateView.as_view(), name="project_create"),
+    path("projects/<int:pk>/", ProjectDetailView.as_view(), name="project_detail"),
+
+    path("threads/", ThreadListView.as_view(), name="thread_list"),
+    path("threads/<int:pk>/", ThreadDetailView.as_view(), name="thread_detail"),
+
+    # API
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema")),
+    path("api/auth/", include("users.urls")),
+    path("api/marketplace/", include("marketplace.urls")),
+    path("api/messaging/", include("messaging.urls")),
+    path("api/payments/", include("payments.urls")),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,0 +1,12 @@
+from django.views.generic import TemplateView
+from marketplace.models import Project
+
+
+class HomeView(TemplateView):
+    template_name = "pages/home.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["latest_projects"] = Project.objects.order_by("-created_at")[:5]
+        return context
+

--- a/marketplace/forms.py
+++ b/marketplace/forms.py
@@ -1,0 +1,27 @@
+from django import forms
+from .models import Project
+
+
+class ProjectForm(forms.ModelForm):
+    class Meta:
+        model = Project
+        fields = [
+            "title",
+            "description",
+            "skills",
+            "budget_min",
+            "budget_max",
+            "deadline",
+            "status",
+        ]
+
+    def clean(self):
+        cleaned = super().clean()
+        min_budget = cleaned.get("budget_min")
+        max_budget = cleaned.get("budget_max")
+        if min_budget is not None and max_budget is not None and min_budget > max_budget:
+            raise forms.ValidationError("Minimum budget cannot exceed maximum budget")
+        skills = cleaned.get("skills")
+        if isinstance(skills, str):
+            cleaned["skills"] = [s.strip() for s in skills.split(',') if s.strip()]
+        return cleaned

--- a/marketplace/views_ssr.py
+++ b/marketplace/views_ssr.py
@@ -1,0 +1,52 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
+from django.urls import reverse_lazy
+from django.views.generic import ListView, DetailView, CreateView
+from .models import Project
+from .forms import ProjectForm
+
+
+class ProjectsListView(ListView):
+    model = Project
+    template_name = "pages/marketplace/projects_list.html"
+    paginate_by = 10
+
+    def get_queryset(self):
+        qs = Project.objects.all().order_by("-created_at")
+        status = self.request.GET.get("status")
+        if status:
+            qs = qs.filter(status=status)
+        skill = self.request.GET.get("skill")
+        if skill:
+            skills = [s.strip() for s in skill.split(",") if s.strip()]
+            qs = qs.filter(skills__contains=skills)
+        budget_min = self.request.GET.get("budget_min")
+        budget_max = self.request.GET.get("budget_max")
+        if budget_min:
+            qs = qs.filter(budget_min__gte=budget_min)
+        if budget_max:
+            qs = qs.filter(budget_max__lte=budget_max)
+        return qs
+
+
+class ProjectDetailView(DetailView):
+    model = Project
+    template_name = "pages/marketplace/project_detail.html"
+
+
+class ProjectCreateView(LoginRequiredMixin, CreateView):
+    model = Project
+    form_class = ProjectForm
+    template_name = "pages/marketplace/project_create.html"
+    success_url = reverse_lazy("projects_list")
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return self.handle_no_permission()
+        if request.user.role != "client":
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)
+
+    def form_valid(self, form):
+        form.instance.client = self.request.user
+        return super().form_valid(form)

--- a/messaging/forms.py
+++ b/messaging/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+from .models import Message
+
+
+class MessageForm(forms.ModelForm):
+    class Meta:
+        model = Message
+        fields = ["body"]

--- a/messaging/views_ssr.py
+++ b/messaging/views_ssr.py
@@ -1,0 +1,46 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
+from django.urls import reverse_lazy
+from django.views.generic import ListView, DetailView
+from django.views.generic.edit import FormMixin
+from django.shortcuts import redirect
+from .models import Thread, Message
+from .forms import MessageForm
+
+
+class ThreadListView(LoginRequiredMixin, ListView):
+    model = Thread
+    template_name = "pages/messaging/thread_list.html"
+
+    def get_queryset(self):
+        return self.request.user.threads.all()
+
+
+class ThreadDetailView(LoginRequiredMixin, FormMixin, DetailView):
+    model = Thread
+    form_class = MessageForm
+    template_name = "pages/messaging/thread_detail.html"
+
+    def get_success_url(self):
+        return reverse_lazy("thread_detail", args=[self.kwargs["pk"]])
+
+    def dispatch(self, request, *args, **kwargs):
+        thread = self.get_object()
+        if request.user not in thread.participants.all():
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        form = self.get_form()
+        if form.is_valid():
+            return self.form_valid(form)
+        return self.form_invalid(form)
+
+    def form_valid(self, form):
+        Message.objects.create(
+            thread=self.get_object(),
+            sender=self.request.user,
+            body=form.cleaned_data["body"],
+        )
+        return redirect(self.get_success_url())

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,0 +1,9 @@
+:root{
+  --brand-1:#3d348b; --brand-2:#7678ed; --accent-1:#f7b801; --accent-2:#f18701; --accent-3:#f35b04;
+}
+body{font-family:system-ui,sans-serif;line-height:1.5;padding:1rem;}
+.navbar{display:flex;gap:1rem;align-items:center;}
+.navbar ul{display:flex;gap:1rem;list-style:none;margin-left:auto;}
+.card{border:1px solid #ccc;padding:1rem;margin:0.5rem 0;}
+.flash-messages .message{padding:0.5rem;margin:0.5rem 0;background:var(--accent-2);color:#fff;}
+@media (min-width:768px){body{max-width:800px;margin:0 auto;padding:2rem;}}

--- a/static/css/reset.css
+++ b/static/css/reset.css
@@ -1,0 +1,2 @@
+/* minimal reset */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}

--- a/static/img/logo.svg
+++ b/static/img/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="30">
+  <text x="0" y="20" font-size="20" fill="#3d348b">Uzinex</text>
+</svg>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.flash-messages .message').forEach(m => {
+    setTimeout(() => m.remove(), 4000);
+  });
+  document.querySelectorAll('[data-logout]').forEach(el => {
+    el.addEventListener('click', e => {
+      if(!confirm('Logout?')) e.preventDefault();
+    });
+  });
+});
+
+function getCookie(name){
+  let value = `; ${document.cookie}`;
+  let parts = value.split(`; ${name}=`);
+  if(parts.length === 2) return parts.pop().split(';').shift();
+}
+
+function csrfFetch(url, options={}){
+  options.method = options.method || 'POST';
+  options.headers = options.headers || {};
+  options.headers['X-CSRFToken'] = getCookie('csrftoken');
+  return fetch(url, options);
+}

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/templates/_partials/_footer.html
+++ b/templates/_partials/_footer.html
@@ -1,0 +1,4 @@
+<footer class="footer">
+  <p>&copy; {{ PROJECT_NAME }} {{ now|date:'Y' }}</p>
+  <p><a href="/api/docs/">API Docs</a></p>
+</footer>

--- a/templates/_partials/_head.html
+++ b/templates/_partials/_head.html
@@ -1,0 +1,6 @@
+{% load static %}
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>{% block title %}{{ PROJECT_NAME }}{% endblock %}</title>
+<link rel="icon" href="{% static 'img/logo.svg' %}" />
+<!-- {% comment %}django-compressor hook{% endcomment %} -->

--- a/templates/_partials/_messages.html
+++ b/templates/_partials/_messages.html
@@ -1,0 +1,7 @@
+{% if messages %}
+<div class="flash-messages">
+  {% for message in messages %}
+  <div class="message {{ message.tags }}">{{ message }}</div>
+  {% endfor %}
+</div>
+{% endif %}

--- a/templates/_partials/_navbar.html
+++ b/templates/_partials/_navbar.html
@@ -1,0 +1,18 @@
+{% load static %}
+<nav class="navbar">
+  <a href="{% url 'home' %}" class="logo"><img src="{% static 'img/logo.svg' %}" alt="Uzinex" /></a>
+  <ul>
+    <li><a href="{% url 'home' %}">Home</a></li>
+    <li><a href="{% url 'projects_list' %}">Projects</a></li>
+    {% if user.is_authenticated %}
+      <li><a href="{% url 'me' %}">Me</a></li>
+      {% if user.role == 'client' %}
+      <li><a href="{% url 'project_create' %}">New Project</a></li>
+      {% endif %}
+      <li><a href="{% url 'logout' %}" data-logout>Logout</a></li>
+    {% else %}
+      <li><a href="{% url 'login' %}">Login</a></li>
+      <li><a href="{% url 'register' %}">Register</a></li>
+    {% endif %}
+  </ul>
+</nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,20 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% include '_partials/_head.html' %}
+    <link rel="stylesheet" href="{% static 'css/reset.css' %}">
+    <link rel="stylesheet" href="{% static 'css/main.css' %}">
+    {% block head_extra %}{% endblock %}
+  </head>
+  <body>
+    {% include '_partials/_navbar.html' %}
+    {% include '_partials/_messages.html' %}
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+    {% include '_partials/_footer.html' %}
+    <script src="{% static 'js/app.js' %}"></script>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/templates/emails/base_email.html
+++ b/templates/emails/base_email.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/templates/emails/password_reset.html
+++ b/templates/emails/password_reset.html
@@ -1,0 +1,4 @@
+{% extends 'emails/base_email.html' %}
+{% block content %}
+<p>Password reset link: {{ reset_link }}</p>
+{% endblock %}

--- a/templates/emails/welcome_client.html
+++ b/templates/emails/welcome_client.html
@@ -1,0 +1,4 @@
+{% extends 'emails/base_email.html' %}
+{% block content %}
+<p>Thank you for registering as a Client at {{ PROJECT_NAME }}.</p>
+{% endblock %}

--- a/templates/emails/welcome_freelancer.html
+++ b/templates/emails/welcome_freelancer.html
@@ -1,0 +1,4 @@
+{% extends 'emails/base_email.html' %}
+{% block content %}
+<p>Thank you for registering as a Freelancer at {{ PROJECT_NAME }}.</p>
+{% endblock %}

--- a/templates/pages/auth/login.html
+++ b/templates/pages/auth/login.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Login - {{ PROJECT_NAME }}{% endblock %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/pages/auth/register.html
+++ b/templates/pages/auth/register.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Register - {{ PROJECT_NAME }}{% endblock %}
+{% block content %}
+<h2>Register</h2>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Register</button>
+</form>
+{% endblock %}

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}Home - {{ PROJECT_NAME }}{% endblock %}
+{% block content %}
+<h1>Welcome to {{ PROJECT_NAME }}</h1>
+<p><a href="{% url 'projects_list' %}">Browse Projects</a></p>
+<div class="projects">
+  {% for project in latest_projects %}
+  <div class="card">
+    <h3><a href="{% url 'project_detail' project.pk %}">{{ project.title }}</a></h3>
+    <p>{{ project.description|truncatechars:100 }}</p>
+  </div>
+  {% empty %}
+  <p>No projects yet.</p>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/templates/pages/marketplace/project_create.html
+++ b/templates/pages/marketplace/project_create.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}New Project - {{ PROJECT_NAME }}{% endblock %}
+{% block content %}
+<h2>Create Project</h2>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Create</button>
+</form>
+{% endblock %}

--- a/templates/pages/marketplace/project_detail.html
+++ b/templates/pages/marketplace/project_detail.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}{{ object.title }} - {{ PROJECT_NAME }}{% endblock %}
+{% block content %}
+<h2>{{ object.title }}</h2>
+<p>{{ object.description }}</p>
+<p>Budget: {{ object.budget_min }} - {{ object.budget_max }}</p>
+<p>Skills: {{ object.skills|join:', ' }}</p>
+<p>Status: {{ object.status }}</p>
+<p><a href="#">Send proposal</a></p>
+{% endblock %}

--- a/templates/pages/marketplace/projects_list.html
+++ b/templates/pages/marketplace/projects_list.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Projects - {{ PROJECT_NAME }}{% endblock %}
+{% block content %}
+<h2>Projects</h2>
+<form method="get" class="filters">
+  <input type="text" name="status" placeholder="Status" value="{{ request.GET.status }}" />
+  <input type="text" name="skill" placeholder="Skills" value="{{ request.GET.skill }}" />
+  <input type="number" step="0.01" name="budget_min" placeholder="Budget min" value="{{ request.GET.budget_min }}" />
+  <input type="number" step="0.01" name="budget_max" placeholder="Budget max" value="{{ request.GET.budget_max }}" />
+  <button type="submit">Apply</button>
+</form>
+{% for project in object_list %}
+<div class="card">
+  <h3><a href="{% url 'project_detail' project.pk %}">{{ project.title }}</a></h3>
+  <p>{{ project.description|truncatechars:150 }}</p>
+</div>
+{% empty %}
+<p>No projects.</p>
+{% endfor %}
+{% endblock %}

--- a/templates/pages/messaging/thread_detail.html
+++ b/templates/pages/messaging/thread_detail.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block title %}Thread - {{ PROJECT_NAME }}{% endblock %}
+{% block content %}
+<h2>Thread for {{ object.project.title }}</h2>
+<div class="messages">
+  {% for m in object.messages.all %}
+  <div class="message"><strong>{{ m.sender.username }}:</strong> {{ m.body }}</div>
+  {% endfor %}
+</div>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Send</button>
+</form>
+{% endblock %}

--- a/templates/pages/messaging/thread_list.html
+++ b/templates/pages/messaging/thread_list.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Threads - {{ PROJECT_NAME }}{% endblock %}
+{% block content %}
+<h2>Your Threads</h2>
+<ul>
+  {% for thread in object_list %}
+  <li><a href="{% url 'thread_detail' thread.pk %}">{{ thread.project.title }}</a></li>
+  {% empty %}
+  <li>No threads.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/pages/users/me.html
+++ b/templates/pages/users/me.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}My Profile - {{ PROJECT_NAME }}{% endblock %}
+{% block content %}
+<h2>{{ request.user.username }}</h2>
+<p>{{ request.user.email }}</p>
+<p>{{ request.user.profile.bio }}</p>
+{% if request.user.profile.skills %}
+<ul>
+  {% for skill in request.user.profile.skills %}
+  <li>{{ skill }}</li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>Add skills</p>
+{% endif %}
+<p><a href="{% url 'profile_edit' %}">Edit Profile</a></p>
+{% endblock %}

--- a/templates/pages/users/profile_edit.html
+++ b/templates/pages/users/profile_edit.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Edit Profile - {{ PROJECT_NAME }}{% endblock %}
+{% block content %}
+<h2>Edit Profile</h2>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,0 +1,60 @@
+from django import forms
+from django.contrib.auth import authenticate
+from django.contrib.auth import get_user_model
+from .models import Profile
+
+User = get_user_model()
+
+
+class LoginForm(forms.Form):
+    username = forms.CharField()
+    password = forms.CharField(widget=forms.PasswordInput)
+
+    def clean(self):
+        cleaned = super().clean()
+        user = authenticate(
+            username=cleaned.get("username"), password=cleaned.get("password")
+        )
+        if not user:
+            raise forms.ValidationError("Invalid credentials")
+        cleaned["user"] = user
+        return cleaned
+
+
+class RegisterForm(forms.ModelForm):
+    password = forms.CharField(widget=forms.PasswordInput)
+
+    class Meta:
+        model = User
+        fields = ["username", "email", "password", "role"]
+
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.set_password(self.cleaned_data["password"])
+        if commit:
+            user.save()
+        return user
+
+
+class ProfileForm(forms.ModelForm):
+    skills = forms.CharField(required=False, widget=forms.Textarea)
+
+    class Meta:
+        model = Profile
+        fields = ["bio", "skills", "hourly_rate", "avatar"]
+
+    def clean_skills(self):
+        data = self.cleaned_data.get("skills", "")
+        if not data:
+            return []
+        if isinstance(data, list):
+            return data
+        lines = [s.strip() for s in data.splitlines() if s.strip()]
+        return lines
+
+    def save(self, commit=True):
+        profile = super().save(commit=False)
+        profile.skills = self.cleaned_data.get("skills", [])
+        if commit:
+            profile.save()
+        return profile

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
-from .views import RegisterView, MeView, ProfileUpdateView
+from .views import RegisterAPIView, MeAPIView, ProfileUpdateAPIView
 
 urlpatterns = [
-    path('register/', RegisterView.as_view()),
+    path('register/', RegisterAPIView.as_view()),
     path('token/', TokenObtainPairView.as_view()),
     path('token/refresh/', TokenRefreshView.as_view()),
-    path('me/', MeView.as_view()),
-    path('me/profile/', ProfileUpdateView.as_view()),
+    path('me/', MeAPIView.as_view()),
+    path('me/profile/', ProfileUpdateAPIView.as_view()),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -1,11 +1,18 @@
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from django.contrib import auth, messages
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import redirect
+from django.urls import reverse_lazy
+from django.views.generic import TemplateView, FormView
+from django.template.loader import render_to_string
 from .models import User
 from .serializers import UserSerializer, RegisterSerializer, ProfileSerializer
+from .forms import LoginForm, RegisterForm, ProfileForm
 
 
-class RegisterView(APIView):
+class RegisterAPIView(APIView):
     """Register a new user."""
     permission_classes = [permissions.AllowAny]
 
@@ -16,7 +23,7 @@ class RegisterView(APIView):
         return Response(UserSerializer(user).data, status=status.HTTP_201_CREATED)
 
 
-class MeView(generics.RetrieveAPIView):
+class MeAPIView(generics.RetrieveAPIView):
     """Return current authenticated user with profile."""
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]
@@ -25,10 +32,71 @@ class MeView(generics.RetrieveAPIView):
         return self.request.user
 
 
-class ProfileUpdateView(generics.UpdateAPIView):
+class ProfileUpdateAPIView(generics.UpdateAPIView):
     """Update current user's profile."""
     serializer_class = ProfileSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_object(self):
         return self.request.user.profile
+
+
+# SSR views
+
+
+class LoginView(FormView):
+    template_name = "pages/auth/login.html"
+    form_class = LoginForm
+    success_url = reverse_lazy("home")
+
+    def form_valid(self, form):
+        auth.login(self.request, form.cleaned_data["user"])
+        messages.success(self.request, "Logged in successfully")
+        return super().form_valid(form)
+
+
+class RegisterView(FormView):
+    template_name = "pages/auth/register.html"
+    form_class = RegisterForm
+    success_url = reverse_lazy("home")
+
+    def form_valid(self, form):
+        user = form.save()
+        auth.login(self.request, user)
+        template = (
+            "emails/welcome_client.html"
+            if user.role == "client"
+            else "emails/welcome_freelancer.html"
+        )
+        render_to_string(template, {"user": user})
+        messages.success(self.request, "Registration successful")
+        return super().form_valid(form)
+
+
+def logout_view(request):
+    auth.logout(request)
+    messages.info(request, "Logged out")
+    return redirect("home")
+
+
+class MeView(LoginRequiredMixin, TemplateView):
+    template_name = "pages/users/me.html"
+
+
+class ProfileEditView(LoginRequiredMixin, FormView):
+    template_name = "pages/users/profile_edit.html"
+    form_class = ProfileForm
+    success_url = reverse_lazy("me")
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["instance"] = self.request.user.profile
+        initial = kwargs.get("initial", {})
+        initial["skills"] = "\n".join(self.request.user.profile.skills)
+        kwargs["initial"] = initial
+        return kwargs
+
+    def form_valid(self, form):
+        form.save()
+        messages.success(self.request, "Profile updated")
+        return super().form_valid(form)


### PR DESCRIPTION
## Summary
- configure Django templates and static files with WhiteNoise
- add SSR views, forms and basic pages for auth, profiles, projects and messaging
- include starter CSS/JS assets and email templates
- remove binary favicon placeholder and use SVG icon

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a0cd3df0b4832291084c6ceb25f57d